### PR TITLE
Use lr scheduler instead of decay argument to be compatible with tf>=2.3

### DIFF
--- a/NES/NeuralEikonalSolver.py
+++ b/NES/NeuralEikonalSolver.py
@@ -301,7 +301,11 @@ class NES_OP:
                 **kwargs : keyword arguments : Arguments for 'tf.keras.models.Model.compile(**kwargs)'
         """
         if optimizer is None:
-            optimizer = tf.optimizers.Adam(learning_rate=lr, decay=decay)
+            lr_schedule = tf.keras.optimizers.schedules.ExponentialDecay(
+                initial_learning_rate=lr,
+                decay_steps=1,
+                decay_rate=decay)
+            optimizer = tf.optimizers.Adam(learning_rate=lr_schedule)
 
         self.model.compile(optimizer=optimizer, loss=loss, **kwargs)
         self.compiled = True
@@ -986,7 +990,11 @@ class NES_TP:
                 **kwargs : keyword arguments : Arguments for 'tf.keras.models.Model.compile(**kwargs)'
         """
         if optimizer is None:
-            optimizer = tf.optimizers.Adam(learning_rate=lr, decay=decay)
+            lr_schedule = tf.keras.optimizers.schedules.ExponentialDecay(
+                initial_learning_rate=lr,
+                decay_steps=1,
+                decay_rate=decay)
+            optimizer = tf.optimizers.Adam(learning_rate=lr_schedule)
 
         self.model.compile(optimizer=optimizer, loss=loss, **kwargs)
         self.compiled = True


### PR DESCRIPTION
In the current colab notebooks when running the cell

```
h = Eik.train(x_train=num_pts, epochs=1500, verbose=0,
              callbacks=[TqdmCallback(verbose=0, miniters=10, mininterval=5)], # progress bar
              batch_size=int(num_pts/4),
              )
```

the following error shows up:

```
ValueError: decay is deprecated in the new Keras optimizer, please check the docstring for valid arguments, or use the legacy optimizer, e.g., tf.keras.optimizers.legacy.Adam.
```

This pull request adds a simple change that gets rid of this error but should keep the functionality the same. For the future it might be better to change the `decay` argument to an `lr_scheduler` argument for more flexibility, which would break some of the tutorials.

see: https://stackoverflow.com/questions/74734685/how-to-fix-this-value-error-valueerror-decay-is-deprecated-in-the-new-keras-o